### PR TITLE
 fix: use z.array(z.unknown()) to fix VS Code MCP schema validation error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makafeli/n8n-workflow-builder",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makafeli/n8n-workflow-builder",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",
         "axios": "^1.11.0",
@@ -26,6 +26,10 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/makafeli"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -73,6 +77,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1388,6 +1393,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2072,6 +2078,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2788,6 +2795,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4688,6 +4696,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4920,6 +4929,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,10 +60,10 @@ server.tool(
   {
     workflow: z.object({
       name: z.string().describe("Name of the workflow"),
-      nodes: z.array(z.any()).describe("Array of workflow nodes"),
+      nodes: z.array(z.unknown()).describe("Array of workflow nodes"),
       connections: z.record(z.string(), z.any()).optional().describe("Node connections"),
       settings: z.record(z.string(), z.any()).optional().describe("Workflow settings"),
-      tags: z.array(z.any()).optional().describe("Workflow tags")
+      tags: z.array(z.unknown()).optional().describe("Workflow tags")
     }).describe("Workflow configuration")
   },
   async ({ workflow }) => {
@@ -121,10 +121,10 @@ server.tool(
     id: z.string().describe("Workflow ID"),
     workflow: z.object({
       name: z.string().optional().describe("Name of the workflow"),
-      nodes: z.array(z.any()).optional().describe("Array of workflow nodes"),
+      nodes: z.array(z.unknown()).optional().describe("Array of workflow nodes"),
       connections: z.record(z.string(), z.any()).optional().describe("Node connections"),
       settings: z.record(z.string(), z.any()).optional().describe("Workflow settings"),
-      tags: z.array(z.any()).optional().describe("Workflow tags")
+      tags: z.array(z.unknown()).optional().describe("Workflow tags")
     }).describe("Updated workflow configuration")
   },
   async ({ id, workflow }) => {
@@ -278,10 +278,10 @@ server.tool(
   {
     workflow: z.object({
       name: z.string().describe("Name of the workflow"),
-      nodes: z.array(z.any()).describe("Array of workflow nodes"),
+      nodes: z.array(z.unknown()).describe("Array of workflow nodes"),
       connections: z.record(z.string(), z.any()).optional().describe("Node connections"),
       settings: z.record(z.string(), z.any()).optional().describe("Workflow settings"),
-      tags: z.array(z.any()).optional().describe("Workflow tags")
+      tags: z.array(z.unknown()).optional().describe("Workflow tags")
     }).describe("Workflow configuration")
   },
   async ({ workflow }) => {


### PR DESCRIPTION
## Problem

When using this MCP server with **GitHub Copilot in VS Code (≥1.99)**, all tools that accept workflow objects fail to load with the error:

> `tool parameters array type must have items`

VS Code validates MCP tool parameter schemas against the JSON Schema spec, which requires array types to include an `items` field. The current code uses `z.array(z.any())`, which compiles to `{"type": "array"}` — missing `items`.

## Fix

Change `z.array(z.any())` → `z.array(z.unknown())` for `nodes` and `tags` parameters. `z.unknown()` compiles to `{}` as the items schema, producing valid JSON Schema: `{"type": "array", "items": {}}`.

## Affected tools

- `create_workflow`
- `update_workflow`
- `create_workflow_and_activate`

## Impact

- **No runtime behaviour change** — `z.unknown()` accepts any value at runtime, same as `z.any()`
- **Fixes VS Code MCP tool loading** for all array-typed workflow parameters
- All other array parameters (`tagIds`, `categories`) already use typed schemas and are unaffected

## Tested

Verified with VS Code 1.111.0 + GitHub Copilot extension in Agent mode. After this fix, all 23 tools appear correctly and workflow CRUD operations work end-to-end.